### PR TITLE
Improve type support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
-import { Block, Edit, Props, VElement, VNode } from './types';
+import type { Block, Edit, Props, VElement, VNode } from './types';
 
 // Helper function to create virtual dom nodes
 // e.g. h('div', { id: 'foo' }, 'hello') => <div id="foo">hello</div>
 export const h = (
   type: string,
-  props: Props = {},
+  props: Props | null = {},
   ...children: VNode[]
 ): VElement => ({
   type,
-  props,
+  props: props || {},
   children,
 });
 
@@ -83,12 +83,12 @@ export const render = (
 // block is a factory function that returns a function that
 // can be used to create a block. Imagine it as a live instance
 // you can use to patch it against instances of itself.
-export const block = (fn: (props: Props) => VNode) => {
+export const block = <TProps extends Props = Props>(fn: (props: TProps) => VNode) => {
   // by using a proxy, we can intercept ANY property access on
   // the object and return a Hole instance instead.
   // e.g. props.any_prop => new Hole('any_prop')
   const proxy = new Proxy(
-    {},
+    {} as TProps,
     {
       get(_, prop: string) {
         return new Hole(prop);
@@ -106,7 +106,7 @@ export const block = (fn: (props: Props) => VNode) => {
   const root = render(vnode, edits);
 
   // factory function to create instances of this block
-  return (props: Props): Block => {
+  return (props: TProps): Block => {
     // elements stores the element references for each edit
     // during mount, which can be used during patch later
     const elements = new Array(edits.length);


### PR DESCRIPTION
### What's been changed?

 - Added props generic to `block` function
	 - This way a user can define their props explicitly by passing a generic. EG:
	 	```ts
		interface NameProps {
			name: string;
		}

		const Name = block<NameProps>(({ name }) => h('span', null, name));

		Name({
  			name: 'hello'
  			// ^? string
		})
		```
 - Updated `h` function to allow for nullable `props`
	 - This is primarily a fix in response to the README.md example which calls `h('button', null, number)` but `null` is not a valid parameter.
 - Updated import to be type explicit
	 - General good common practice, at least imo, to clearly label type imports as such. Since all imports from `types.ts` are types, I have changed the whole block to a type import.
